### PR TITLE
Allow Laravel 12 and 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/database": "^9.21|^10.0|^11.0",
-        "illuminate/support": "^9.21|^10.0|^11.0",
+        "illuminate/database": "^9.21|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^9.21|^10.0|^11.0|^12.0|^13.0",
         "nesbot/carbon": "^2.0|^3.0",
-        "symfony/http-kernel": "^6.0|^7.0",
+        "symfony/http-kernel": "^6.0|^7.0|^8.0",
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
-        "illuminate/http": "^9.21|^10.0|^11.0",
-        "illuminate/routing": "^9.21|^10.0|^11.0",
+        "illuminate/http": "^9.21|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/routing": "^9.21|^10.0|^11.0|^12.0|^13.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^9.0",
         "vlucas/phpdotenv": "^3.3",


### PR DESCRIPTION
Widens the `illuminate/*` constraints to include `^12.0` and `^13.0`, and `symfony/http-kernel` to include `^8.0` (Laravel 13 ships Symfony 8 components).

**Purely additive.** `^9.21`, `^10.0` and `^11.0` continue to resolve, so nothing currently consuming this package is affected.

No source changes were needed.

### Verification

Tested against **Laravel 13.25.0 on PHP 8.4** in the StorePulse "My Account" application. The FastSpring billing suite passes unchanged:

- subscription upgrade + proration estimates
- upgrade-revert on failed charge
- invoice/billing history
- customer creation from `order.completed` / `subscription.activated` webhooks

Also verified on Laravel 12.66.0.

### Why this is needed

This constraint is currently the only thing blocking that application from upgrading past Laravel 11.